### PR TITLE
Support precomposed Apple icons

### DIFF
--- a/Sources/FavIcon/Detection.swift
+++ b/Sources/FavIcon/Detection.swift
@@ -56,7 +56,8 @@ func detectHTMLHeadIcons(_ document: HTMLDocument, baseURL: URL) -> [Icon] {
             } else {
                 icons.append(Icon(url: url.absoluteURL, type: .classic))
             }
-        case "apple-touch-icon":
+        case "apple-touch-icon",
+             "apple-touch-icon-precomposed":
             let sizes = parseHTMLIconSizes(link.attributes["sizes"])
             if sizes.count > 0 {
                 for size in sizes {


### PR DESCRIPTION
Some sites use a precomposed icon for display on Apple devices.